### PR TITLE
Switch to kingpin for flag handling and enable log flags

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.0.3-gitlab
+0.0.4-gitlab

--- a/pgbouncer_exporter.go
+++ b/pgbouncer_exporter.go
@@ -1,14 +1,13 @@
 package main
 
 import (
-	"flag"
 	"fmt"
 	"net/http"
-	"os"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/common/log"
 	"github.com/prometheus/common/version"
+	"gopkg.in/alecthomas/kingpin.v2"
 )
 
 const (
@@ -29,18 +28,15 @@ const (
 
 func main() {
 	var (
-		showVersion             = flag.Bool("version", false, "Print version information.")
-		listenAddress           = flag.String("web.listen-address", ":9127", "Address on which to expose metrics and web interface.")
-		connectionStringPointer = flag.String("pgBouncer.connectionString", "postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable", "Connection string for accessing pgBouncer.")
-		metricsPath             = flag.String("web.telemetry-path", "/metrics", "Path under which to expose metrics.")
+		connectionStringPointer = kingpin.Flag("pgBouncer.connectionString", "Connection string for accessing pgBouncer.").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").String()
+		listenAddress           = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9127").String()
+		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 	)
 
-	flag.Parse()
-
-	if *showVersion {
-		fmt.Fprintln(os.Stdout, version.Print("pgbouncer_exporter"))
-		os.Exit(0)
-	}
+	log.AddFlags(kingpin.CommandLine)
+	kingpin.Version(version.Print("pgbouncer_exporter"))
+	kingpin.HelpFlag.Short('h')
+	kingpin.Parse()
 
 	connectionString := *connectionStringPointer
 	exporter := NewExporter(connectionString, namespace)


### PR DESCRIPTION
Like all official exporters, we should migrate to `kingpin` as well, for flag management.
>**Note**, this is breaking change, all flags now must be prefixed with double dash (`--`)