### PR TITLE
Fix for invalid labels

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -127,7 +127,8 @@ func queryNamespaceMapping(ch chan<- prometheus.Metric, db *sql.DB, namespace st
 
 					// Prometheus will fail hard if the database and usernames are not UTF-8
 					if !utf8.ValidString(labelValues[i]) {
-						nonfatalErrors = append(nonfatalErrors, errors.New(fmt.Sprintln("Column %s in %s has an invalid UTF-8 for a label: %s ", columnName, namespace, columnData[idx])))
+						nonfatalErrors = append(nonfatalErrors, fmt.Errorf("Column %s in %s has an invalid UTF-8 for a label: %s ", columnName, namespace, columnData[idx]))
+						labelValues[i] = "<invalid>"
 						continue
 					}
 				}


### PR DESCRIPTION
This change fixes a panic when encountering an invalid label value.

The previous fix added an additional nonfatal error for non-UTF8 strings, but still attempted to persist the metric with the invalid label. 

This replaces the invalid value with `<invalid>`. Having deployed this change into a production environment, it was still helpful to know the other label values, so I prefer this solution to not persisting the series, which is an alternative solution.