### PR TITLE
Add missing rows.Err() check to detect rows.Scan failures

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -155,6 +155,10 @@ func queryNamespaceMapping(ch chan<- prometheus.Metric, db *sql.DB, namespace st
 			}
 		}
 	}
+	if err := rows.Err(); err != nil {
+		log.Errorf("Failed scaning all rows due to scan failure: error was; %s", err)
+		nonfatalErrors = append(nonfatalErrors, errors.New(fmt.Sprintf("Failed to consume all rows due to: %s", err)))
+	}
 	return nonfatalErrors, nil
 }
 


### PR DESCRIPTION
Without this, pgbouncer exporter- when ran against a long running high
thoroughput pgbouncer instance- can stop reporting all database stats
due to the internal scanner failing to do conversions to 64bit ints.

Without this check, those errors are completely lost; this doesn't fix
issue #10, but it does fix the bug that was hiding the failure.