### PR TITLE
Add info metrics

### DIFF
--- a/.promu.yml
+++ b/.promu.yml
@@ -3,11 +3,11 @@ repository:
 build:
     flags: -mod=vendor -a -tags 'netgo static_build'
     ldflags: |
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Version={{.Version}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Revision={{.Revision}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.Branch={{.Branch}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
-        -X {{repoPath}}/vendor/github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
+        -X github.com/prometheus/common/version.Version={{.Version}}
+        -X github.com/prometheus/common/version.Revision={{.Revision}}
+        -X github.com/prometheus/common/version.Branch={{.Branch}}
+        -X github.com/prometheus/common/version.BuildUser={{user}}@{{host}}
+        -X github.com/prometheus/common/version.BuildDate={{date "20060102-15:04:05"}}
 tarball:
     files:
         - LICENSE

--- a/Makefile.common
+++ b/Makefile.common
@@ -74,7 +74,7 @@ PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_
 
 GOLANGCI_LINT :=
 GOLANGCI_LINT_OPTS ?=
-GOLANGCI_LINT_VERSION ?= v1.16.0
+GOLANGCI_LINT_VERSION ?= v1.18.0
 # golangci-lint only supports linux, darwin and windows platforms on i386/amd64.
 # windows isn't included here because of the path separator being different.
 ifeq ($(GOHOSTOS),$(filter $(GOHOSTOS),linux darwin))
@@ -201,7 +201,7 @@ endif
 .PHONY: common-build
 common-build: promu
 	@echo ">> building binaries"
-	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX)
+	GO111MODULE=$(GO111MODULE) $(PROMU) build --prefix $(PREFIX) $(PROMU_BINARIES)
 
 .PHONY: common-tarball
 common-tarball: promu

--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.1.1-gitlab
+0.1.2-gitlab

--- a/pgbouncer_exporter.go
+++ b/pgbouncer_exporter.go
@@ -42,6 +42,7 @@ func main() {
 	connectionString := *connectionStringPointer
 	exporter := NewExporter(connectionString, namespace)
 	prometheus.MustRegister(exporter)
+	prometheus.MustRegister(version.NewCollector("pgbouncer_exporter"))
 
 	log.Infoln("Starting pgbouncer exporter version: ", version.Info())
 


### PR DESCRIPTION
* Add exporter build info metric.
* Add pgbouncer version info metric.
* Update Makefile.common.
* Fix path to version embedding in promu config.
* Make scrape errors non-fatal.

Signed-off-by: Ben Kochie <superq@gmail.com>