### PR TITLE
fix: fix conversion function litteral

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -408,6 +408,8 @@ func makeDescMap(metricMaps map[string]map[string]ColumnMapping, namespace strin
 		}
 
 		for columnName, columnMapping := range mappings {
+			factor := columnMapping.factor
+
 			// Determine how to convert the column based on its usage.
 			switch columnMapping.usage {
 			case COUNTER:
@@ -415,7 +417,7 @@ func makeDescMap(metricMaps map[string]map[string]ColumnMapping, namespace strin
 					vtype: prometheus.CounterValue,
 					desc:  prometheus.NewDesc(fmt.Sprintf("%s_%s_%s", namespace, metricNamespace, columnMapping.metric), columnMapping.description, labels, nil),
 					conversion: func(in interface{}) (float64, bool) {
-						return dbToFloat64(in, columnMapping.factor)
+						return dbToFloat64(in, factor)
 					},
 				}
 			case GAUGE:
@@ -423,7 +425,7 @@ func makeDescMap(metricMaps map[string]map[string]ColumnMapping, namespace strin
 					vtype: prometheus.GaugeValue,
 					desc:  prometheus.NewDesc(fmt.Sprintf("%s_%s_%s", namespace, metricNamespace, columnMapping.metric), columnMapping.description, labels, nil),
 					conversion: func(in interface{}) (float64, bool) {
-						return dbToFloat64(in, columnMapping.factor)
+						return dbToFloat64(in, factor)
 					},
 				}
 			}

--- a/collector.go
+++ b/collector.go
@@ -61,7 +61,7 @@ var (
 	bouncerVersionDesc = prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "version", "info"),
 		"The pgbouncer version info",
-		[]string{"version",}, nil,
+		[]string{"version"}, nil,
 	)
 )
 
@@ -298,7 +298,7 @@ func queryNamespaceMappings(ch chan<- prometheus.Metric, db *sql.DB, metricMap m
 func queryVersion(ch chan<- prometheus.Metric, db *sql.DB) error {
 	rows, err := db.Query("SHOW VERSION;")
 	if err != nil {
-		return errors.New(fmt.Sprintf("error getting pgbouncer version: %v",  err))
+		return errors.New(fmt.Sprintf("error getting pgbouncer version: %v", err))
 	}
 	defer rows.Close()
 


### PR DESCRIPTION
The problem is that some metrics in the stats namespace are always
wrong: either unit counters are multiplied by 1e6, or millisecond
counters are NOT multiplied by 1e6. The reason is that if two metrics in
the same namespace have different values for the factor field, one of
these values is being chosen randomly in NewExporter and used for all
metrics.

That's because we range over a map and use values in a closure inside
the range loop.

The fix is to declare a variable inside the range loop.