### PR TITLE
fix: set the up gauge to 1

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -389,6 +389,11 @@ func (e *Exporter) scrape(ch chan<- prometheus.Metric) {
 		log.Error(errMap)
 		e.error.Set(1)
 	}
+
+	e.up.Set(1)
+	if len(errMap) == len(e.metricMap) {
+		e.up.Set(0)
+	}
 }
 
 // Turn the MetricMap column mapping into a prometheus descriptor mapping.


### PR DESCRIPTION
If we get 3 errors after doing the 3 queries `SHOW DATABASE`, `SHOW
STATS` and `SHOW POOLS`, set the up gauge to 0. Otherwise, we were able
to talk to pgbouncer so set the up gauge to 1.