### PR TITLE
Fix byte slice values not receiving conversion factor

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -255,7 +255,7 @@ func dbToFloat64(t interface{}, factor float64) (float64, bool) {
 		if err != nil {
 			return math.NaN(), false
 		}
-		return result, true
+		return result * factor, true
 	case string:
 		result, err := strconv.ParseFloat(v, 64)
 		if err != nil {


### PR DESCRIPTION
As reported in https://gitlab.com/gitlab-com/gl-infra/infrastructure/-/issues/9966#note_333208743, a `[]byte` value was not being converted, which can happen with numeric types.